### PR TITLE
Add early FDR filter for PSM integration.

### DIFF
--- a/example/config/config.yaml
+++ b/example/config/config.yaml
@@ -49,3 +49,4 @@ ascore:
 
 integration:
   ngroups: 1
+  fdr_filter: .1

--- a/integration_engine/__init__.py
+++ b/integration_engine/__init__.py
@@ -1,4 +1,4 @@
-from .protein_grouper import *
+from .protein_grouper import PercolatorProteinGrouper
 from .manager import SubintegrationManager
 from .merger import SubintegrationMerger
 from .fdr import FDRCalculator

--- a/integration_engine/manager.py
+++ b/integration_engine/manager.py
@@ -61,7 +61,7 @@ class SubintegrationManager:
                        [protein_groups, group_number, self.fdr_filter])
 
         # Iterate through files in chunks
-        psm_counter = count()
+        psm_counter = count(1)
         session = self._get_session()
         for chunk_start in range(0, len(psm_files), self.file_chunk_size):
             chunk_end = min(len(psm_files), chunk_start + self.file_chunk_size)

--- a/integration_engine/manager.py
+++ b/integration_engine/manager.py
@@ -14,11 +14,12 @@ from .modification_mapper import *
 from .database_schema import *
 
 class SubintegrationManager:
-    def __init__(self, nworkers = 8, file_chunk_size = 1e3, record_chunk_size = 1e4, db_path=None):
+    def __init__(self, nworkers = 8, file_chunk_size = 1e3, record_chunk_size = 1e4, fdr_filter = 1., db_path=None):
         # Processing parameters
         self.nworkers = nworkers
         self.file_chunk_size = int(file_chunk_size)
         self.record_chunk_size = int(record_chunk_size)
+        self.fdr_filter = fdr_filter
 
         # Initialize in memory database
         if db_path is None:
@@ -57,7 +58,7 @@ class SubintegrationManager:
 
         workers = Pool(self.nworkers,
                        PSMMapper.initialize,
-                       [protein_groups, group_number])
+                       [protein_groups, group_number, self.fdr_filter])
 
         # Iterate through files in chunks
         psm_counter = count()

--- a/integration_engine/protein_grouper.py
+++ b/integration_engine/protein_grouper.py
@@ -7,180 +7,14 @@ from itertools import product, cycle, combinations, chain
 from collections import deque
 from multiprocessing import Pool
 
-class InputError(Exception):
-    def __init__(self, message):
-        self.message = message
-
-
-class Digester:
-    def __init__(self, enzyme, min_len=6, max_len=60):
-        # This should be all that you need to change to add a new enzyme
-        # enzyme names <- use lowercase
-        # amino acids <- use UPPERCASE
-        enzyme_regex = {"trypsin" : "[KR](?!P)",
-                        "lysc" : "K"}
-        self.cut_site = re.compile(enzyme_regex[enzyme.lower()])
-        self.min_len = min_len
-        self.max_len = max_len
-
-    def _build_missed_cleavages(self, seq_list, group_size):
-        if group_size > len(seq_list):
-            return []
-
-        args = [iter(seq_list) for i in range(group_size)]
-        for ind, it in enumerate(args):
-            for i in range(ind):
-                next(it)
-
-        return ["".join(peps) for peps in zip(*args)]
-
-    def _size_select(self, peptides):
-        select = [len(p) >= self.min_len and len(p) <= self.max_len for p in peptides]
-        return peptides[select]
-
-    def digest(self, sequence):
-        sequence_digest = [[]]
-
-        last = 0
-        for pep in re.finditer(self.cut_site, sequence):
-            sequence_digest[0].append(sequence[ last:pep.span()[1] ])
-            last = pep.span()[1]
-
-        if last != len(sequence):
-            sequence_digest[0].append(sequence[ last: ])
-        
-        for i in range(self.n_missed):
-            sequence_digest.append(self._build_missed_cleavages(sequence_digest[0], i + 2))
-        
-        sequence_digest = self._size_select(np.concatenate(sequence_digest))
-        return sequence_digest
-
-
-class PeptideExtractor:
-    def __init__(self, file_name, enzyme):
-        self.file_name = file_name
-        self.digester = Digester(enzyme)
-        self.peptide_list = []
-        self.id_list = []
-        self.peptide_df = None
-
-    def _process_fasta_entry(self, sequence_buffer):
-        # Check if proper fasta sequence
-        if (">" != sequence_buffer[0][0] or
-                len(sequence_buffer[0]) == 1):
-            raise InputError("FASTA record lacking header")
-
-        if len(sequence_buffer) == 1:
-            raise InputError("FASTA record lacking sequence")
-
-        sequence_id = sequence_buffer[0].split()[0][1:]
-
-        peptides = self.digester.digest("".join(sequence_buffer[1:]))
-        peptides = [re.sub("[IL]", "X", p) for p in peptides]
-
-        self.peptide_list.extend(peptides)
-        self.id_list.extend([sequence_id] * len(peptides))
-
-    def zip(self):
-        return zip(self.id_list, self.peptide_list)
-
-    def extract(self):
-        with open(self.file_name) as source:
-            sequence_buffer = []
-            for line in source:
-                line = line.rstrip()
-                if line[0] == ">" and len(sequence_buffer) > 0:
-                    self._process_fasta_entry(sequence_buffer)
-                    sequence_buffer = [line]
-
-                else:
-                    sequence_buffer.append(line)
-
-            self._process_fasta_entry(sequence_buffer)
-            self.peptide_df = pd.DataFrame({"ref": self.id_list,
-                                            "peptide": self.peptide_list})
-
-
-class ProteinGrouper:
-    def __init__(self, extractor, n_groups, n_iter=10):
-        self.extractor = extractor
-        self.n_groups = n_groups
-        self.n_iter = n_iter
-        
-        self.inverted_index = None
-        self.protein_matches = None
-        self.group_map = None
-        self.group_var = np.inf
-
-    def _create_inverted_index(self):
-        inverted_index = {}
-        for ref, pep in self.extractor.zip():
-            inverted_index.setdefault(pep, set())
-            inverted_index[pep].add(ref)
-
-        return inverted_index
-
-    def _match_proteins(self):
-        protein_matches = {}
-        for ref_set in self.inverted_index.values():
-            for ref1, ref2 in product(ref_set, ref_set):
-                protein_matches.setdefault(ref1, set())
-                protein_matches[ref1].add(ref2)
-
-        return protein_matches
-
-    def _get_clique(self, ref):
-        clique = set()
-        ref_stack = [ref]
-        ind = 0
-        while ref_stack:
-            print(ind, len(ref_stack), len(clique))
-            ind += 1
-            ref = ref_stack.pop()
-            for ref in self.protein_matches[ref]:
-                if ref not in clique:
-                    clique.add(ref)
-                    ref_stack.append(ref)
-
-        return clique
-
-    def _create_groups(self):
-        references = list(self.protein_matches.keys())
-
-        group_cycle = cycle(range(self.n_groups))
-        group_map = {}
-        for ref in references:
-            if ref not in group_map:
-                clique = self._get_clique(ref)
-                group = next(group_cycle)
-                group_map.update({ref : group for ref in clique})
-
-        _, group_counts = np.unique(list(group_map.values()), return_counts=True)
-        return group_map, np.var(group_counts)
-
-    def group(self):
-        self.extractor.extract()
-        self.inverted_index = self._create_inverted_index()
-        self.protein_matches = self._match_proteins()
-
-        for i in range(self.n_iter):
-            group_map, group_var = self._create_groups()
-            if group_var < self.group_var:
-                self.group_var = group_var
-                self.group_map = group_map
-
-    def to_json(self, file_name, **kwargs):
-        with open(file_name, "w") as dest:
-            json.dump(self.group_map, dest, **kwargs)
-
-
 class PercolatorReader:
     @staticmethod
-    def run(psm_path):
+    def run(psm_path, fdr_filter):
         psm_map = pd.read_csv(
             psm_path, sep="\t",
-            usecols=["scan", "protein id"]
+            usecols=["scan", "percolator q-value", "protein id"]
             ).set_index("scan")
+        psm_map = psm_map[psm_map["percolator q-value"] < fdr_filter]
 
         protein_groups = []
         for prot_list in psm_map["protein id"]:
@@ -195,10 +29,11 @@ class PercolatorReader:
         return protein_groups
 
 class PercolatorProteinGrouper:
-    def __init__(self, n_groups, n_workers, chunk_size):
+    def __init__(self, n_groups, n_workers, chunk_size, fdr_filter=1.):
         self.n_groups = n_groups
         self.n_workers = n_workers
         self.chunk_size = int(chunk_size)
+        self.fdr_filter = fdr_filter
         self.protein_matches = {}
         self.group_map = {}
 
@@ -247,8 +82,9 @@ class PercolatorProteinGrouper:
                   flush=True)
 
             protein_groups = list(chain.from_iterable(
-                workers.map(PercolatorReader.run,
-                            files[chunk_start:chunk_end])
+                workers.starmap(PercolatorReader.run,
+                                [(f, self.fdr_filter)
+                                 for f in files[chunk_start:chunk_end]])
                 ))
             self._match_proteins(protein_groups)
 
@@ -258,15 +94,3 @@ class PercolatorProteinGrouper:
         with open(file_name, "w") as dest:
             json.dump(self.group_map, dest, **kwargs) 
 
-
-if __name__ == "__main__":
-    fasta_name = sys.argv[1]
-    destination = sys.argv[2]
-    n_groups = int(sys.argv[3])
-    pg = PeptideGrouper(
-            PeptideExtractor(fasta_name, "trypsin"),
-            n_groups
-         )
-    pg.group()
-    _, counts = np.unique(list(pg.group_map.values()), return_counts=True)
-    pg.to_json(destination)

--- a/integration_engine/psm_mapper.py
+++ b/integration_engine/psm_mapper.py
@@ -7,12 +7,15 @@ import pandas as pd
 class PSMMapper:
 
     @staticmethod
-    def initialize(protein_groups, group_number):
+    def initialize(protein_groups, group_number, fdr_filter):
         global PROTEIN_GROUPS
         PROTEIN_GROUPS = protein_groups
 
         global GROUP_NUMBER
         GROUP_NUMBER = group_number
+
+        global FDR_FILTER
+        FDR_FILTER = fdr_filter
 
     @staticmethod
     def gather_data(scan_info_path, psm_path, localization_path):
@@ -27,6 +30,7 @@ class PSMMapper:
                                  .sort_values(["scan", "percolator score"])\
                                  .set_index("scan", drop=False)
         psm_scores = psm_scores.drop_duplicates(subset="scan", keep="last")
+        psm_scores = psm_scores[psm_scores["percolator q-value"] <= FDR_FILTER]
 
         select = []
         for prot_list in psm_scores["protein id"]:

--- a/rules/psm_integration.smk
+++ b/rules/psm_integration.smk
@@ -27,9 +27,10 @@ rule group_proteins:
             ), psmLabel=["target", "decoy"]
         )
         percolator_files.sort()
-        pg = PercolatorProteinGrouper(n_groups = config["integration"]["ngroups"], 
-                                      n_workers = 8, 
-                                      chunk_size=1e3)
+        pg = PercolatorProteinGrouper(n_groups=config["integration"]["ngroups"], 
+                                      n_workers=8, 
+                                      chunk_size=1e3,
+                                      fdr_filter=config["integration"]["fdr_filter"])
         pg.group(percolator_files)
         pg.to_json(output.group_file)
 
@@ -85,9 +86,11 @@ rule subintegration:
            )
         
         # Feed files to subintegration     
-        manager = SubintegrationManager(
-            nworkers=8, file_chunk_size=1e3, record_chunk_size=1e4
-        )
+        manager = SubintegrationManager(nworkers=8, 
+                                        file_chunk_size=1e3, 
+                                        record_chunk_size=1e4,
+                                        fdr_filter=config["integration"]["fdr_filter"]
+                                       )
 
         t0 = time.time()
         manager.map_psms(


### PR DESCRIPTION
One thing that I noticed with the initial version of this pipeline is that we spent a lot of time and memory analyzing PTMs that were destined not to be accepted. When a huge amount of data is brought together, only the best PTMs from files are going to survive and be worth our time.

Thus, I added a simple early FDR filter. This filters directly at the Percolator results, so much less PSMs are physically stored in memory when analyzing. I believe this will substantially cut down on the amount of memory needed for analysis, which can potentially make it much more feasible to reach the highest number of analyzed files.